### PR TITLE
Fix OS command injection in database backup/restore utilities

### DIFF
--- a/backend/worker/tasks.py
+++ b/backend/worker/tasks.py
@@ -120,8 +120,15 @@ def backup_db():
 
     try:
         # Dump MySQL database
-        dump_command = f"mysqldump -h {DB_HOST} -u root -p{DB_ROOT_PASSWORD} {DB_NAME} > {backup_file}"
-        subprocess.run(dump_command, shell=True, check=True)
+        dump_command = [
+            'mysqldump',
+            '-h', DB_HOST,
+            '-u', 'root',
+            f'-p{DB_ROOT_PASSWORD}',
+            DB_NAME
+        ]
+        with open(backup_file, 'w') as f:
+            subprocess.run(dump_command, stdout=f, shell=False, check=True)
 
         # Create s3 client
         s3_client = boto3.client(

--- a/deployment/scripts/restore_database.py
+++ b/deployment/scripts/restore_database.py
@@ -49,9 +49,16 @@ def download_from_s3(dump_file_name: str, local_path: str):
 
 
 def apply_dump_to_db(dump_file_path: str):
+    command = [
+        'mysql',
+        '-h', DB_HOST,
+        '-u', 'root',
+        f'-p{DB_ROOT_PASSWORD}',
+        DB_NAME
+    ]
     try:
-        command = f'mysql -h {DB_HOST} -u root -p{DB_ROOT_PASSWORD} {DB_NAME} < {dump_file_path}'
-        subprocess.run(command, shell=True, check=True)
+        with open(dump_file_path, 'r') as f:
+            subprocess.run(command, stdin=f, shell=False, check=True)
         print(f'Applied dump {os.path.basename(dump_file_path)} to database {DB_NAME}')
     except Exception as exception:
         print('Unable to apply dump file.')


### PR DESCRIPTION
- Remove `shell=True` from subprocess calls
- Use argument lists instead of shell string concatenation
- Handle file I/O explicitly instead of shell redirection

Resolves CWE-78 (OS Command Injection) - CVSS 9.8